### PR TITLE
ci: add CI workflow for tests on PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run build
+
+      - run: npm run test


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` so pull requests and pushes to `main` run the project's own quality gates: typecheck, build, and test.
- Mirrors `release.yml` conventions (`actions/checkout@v6`, `actions/setup-node@v6`, Node 24), using `npm ci` + `cache: npm` since `package-lock.json` is committed.

## Test plan
- [x] `npm ci` — installs clean
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm run test` — 23 tests passed across 3 files
- [ ] CI run on this PR turns green
